### PR TITLE
fix(adapter): refine network adapter filtering and sorting in PowerShell command

### DIFF
--- a/src-tauri/src/adapter_commands.rs
+++ b/src-tauri/src/adapter_commands.rs
@@ -6,8 +6,27 @@ pub async fn get_network_adapters() -> Result<String, String> {
     // Get network adapters that are currently up using PowerShell
     // Output as CSV for easier parsing
     // Added InterfaceType to identify if it's WiFi, Ethernet, etc.
+    let ps_script = r#"
+    Get-NetAdapter | 
+    Where-Object { 
+        $_.Status -eq "Up" -and 
+        $_.InterfaceDescription -notlike "*Virtual*" -and
+        $_.InterfaceDescription -notlike "*VMware*" -and
+        $_.InterfaceDescription -notlike "*Hyper-V*" -and
+        $_.InterfaceDescription -notlike "*Loopback*" -and
+        $_.InterfaceDescription -notlike "*VirtualBox*" -and
+        $_.Name -notlike "*Bluetooth*" -and
+        $_.Name -notlike "*isatap*" -and
+        $_.Name -notlike "*teredo*" -and
+        $_.Name -notlike "*6TO4*" -and
+        $_.MediaConnectionState -eq "Connected"
+    } | 
+    Sort-Object LinkSpeed -Descending |
+    Select-Object -First 3 Name, InterfaceDescription, ifIndex, LinkSpeed, InterfaceType | 
+    ConvertTo-Csv -NoTypeInformation
+    "#;
     let output = Command::new("powershell")
-        .args(&["-Command", "Get-NetAdapter | Where-Object Status -eq 'Up' | Select-Object Name, InterfaceDescription, ifIndex, LinkSpeed, InterfaceType | ConvertTo-Csv -NoTypeInformation"])
+        .args(&["-Command", ps_script])
         .output()
         .map_err(|e| format!("Failed to execute PowerShell: {}", e))?;
 

--- a/src/components/TimeCard.tsx
+++ b/src/components/TimeCard.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 export default function TimeCard() {
   const [time, setTime] = useState<string>("Click the button to start");
   const [isTracking, setIsTracking] = useState<boolean>(false);
-  const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null);
+  const [intervalId, setIntervalId] = useState<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     // Clean up interval when component unmounts


### PR DESCRIPTION
- Update PowerShell script to exclude virtual, VMware, Hyper-V, loopback, VirtualBox adapters
- Add more specific filters for adapter names like Bluetooth, isatap, teredo, 6TO4
- Only select adapters with MediaConnectionState as Connected
- Sort adapters by LinkSpeed in descending order and limit to top 3
- Replace deprecated NodeJS.Timeout type with ReturnType<typeof setInterval> in TimeCard component
- Improve interval cleanup to match updated intervalId type usage